### PR TITLE
Fix server termination

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -150,6 +150,11 @@ class WebPBatchServer {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     console.error('WebP Batch MCP server running on stdio');
+
+    // Keep the process alive to handle multiple requests
+    await new Promise(() => {
+      /* intentional noop */
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the MCP server keeps running by awaiting a never-resolving promise

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dccb6b148327bff9710210f9df9a